### PR TITLE
Add gss version of gwt-dnd.css.

### DIFF
--- a/DragDrop/src/com/allen_sauer/gwt/dnd/client/util/gwt-dnd.gss
+++ b/DragDrop/src/com/allen_sauer/gwt/dnd/client/util/gwt-dnd.gss
@@ -1,0 +1,69 @@
+@external dragdrop-dropTarget;
+@external dragdrop-dropTarget-engage;
+@external dragdrop-flow-panel-positioner;
+@external dragdrop-positioner;
+@external dragdrop-boundary;
+@external dragdrop-handle;
+@external dragdrop-draggable;
+@external dragdrop-selected;
+@external dragdrop-dragging;
+@external dragdrop-proxy;
+@external dragdrop-movable-panel;
+	
+HTML { /* Workaround for GWT issue 1932 */
+	margin: 0px !important;
+	border: none !important;
+}
+
+.dragdrop-boundary {
+}
+
+.dragdrop-dropTarget-engage {
+}
+
+.dragdrop-dropTarget {
+}
+
+.dragdrop-handle {
+	cursor: move;
+	user-select: none;
+	-khtml-user-select: none;
+	-moz-user-select: none;
+}
+
+.dragdrop-draggable {
+	zoom: 1; /* IE gain hasLayout */
+}
+
+.dragdrop-dragging {
+	zoom: normal; /* remove artifacts */
+}
+
+.dragdrop-positioner {
+	border: 1px dashed #1E90FF; /* blue */
+	margin: 0px !important;
+	zoom: 1; /* IE gain hasLayout */
+	z-index: 100;
+}
+
+.dragdrop-flow-panel-positioner {
+	color: #1E90FF; /* blue */
+	display: inline;
+	text-align: center;
+	vertical-align: middle;
+}
+
+.dragdrop-proxy {
+	background-color: #77AAFF; /* light blue */
+}
+
+.dragdrop-selected,.dragdrop-dragging,.dragdrop-proxy {
+	filter: alpha(opacity = 30);
+	opacity: 0.3;
+}
+
+.dragdrop-movable-panel {
+	z-index: 200;
+	margin: 0px !important;
+	border: none !important;
+}


### PR DESCRIPTION
With GWT 2.8 the GWT compiler will prefer .gss files if they are
available, thus allowing libs to be compatible with GWT 2.7 and GWT 2.8
if they supply both versions of a file.